### PR TITLE
Load FHIR client during bootstrap

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { CommonService } from './services/common/common.service';
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgxSpinnerService } from 'ngx-spinner';
 import * as _ from 'lodash';
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -8,6 +8,14 @@ import { FormsModule } from '@angular/forms';
 import { NgxSpinnerModule } from 'ngx-spinner';
 // animation module
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ClientService } from './smartonfhir/client.service';
+
+const fhirInitializeFn = (fhirService: ClientService) => {
+  // Grab the client during bootstrap - this prevents the flash of a partially
+  // loaded client if SMART on FHIR needs to do an OAuth authentication prior to
+  // continuing to bootstrap the Angular app
+  return () => fhirService.getClient();
+};
 
 @NgModule({
   declarations: [
@@ -21,7 +29,16 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     NgxSpinnerModule,
     BrowserAnimationsModule
   ],
-  providers: [CommonService],
+  providers: [
+    CommonService,
+    ClientService,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: fhirInitializeFn,
+      multi: true,
+      deps: [ClientService]
+    }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }


### PR DESCRIPTION
This ensures that the SMART on FHIR client is actually available prior to completing the Angular bootstrap - it means that you don't see the app load and then vanish and get replaced with an OAuth dialog, instead you go straight to the OAuth dialog.