### PR TITLE
filtering resources by primary cancer condition date

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -185,21 +185,42 @@ export class AppComponent {
 
     // Gathering resources for patient bundle
     let resourceTypeCount = 0;
-    this.fhirService.resourceTypes.map((resourceType) => {
-      this.fhirService.getResources(resourceType, this.fhirService.resourceParams[resourceType]).then((records) => {
-        this.bundleResources.push(
-          ...(records.filter((record) => {
-            // Check to make sure it's a bundle entry
-            return 'fullUrl' in record && 'resource' in record;
-          }) as fhirclient.FHIR.BundleEntry[])
-        );
-        resourceTypeCount++;
-        if (this.fhirService.resourceTypes.length === resourceTypeCount) {
-          // remove loading screen when we've loaded our final resource type
-          this.spinner.hide('load-record');
+    this.fhirService
+      .getResources('Condition', {
+        _profile: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-primary-cancer-condition'
+      })
+      .then((condition) => {
+        if (condition.length > 0) {
+          // get onset date of primary cancer condition
+          const dateString = condition[0]['resource']['onsetDateTime'];
+          if (dateString) {
+            const newDate = new Date(dateString);
+            newDate.setFullYear(newDate.getFullYear() - 2);
+            const newStringDate = newDate.toISOString();
+            // set search params for resource types: date more recent than 2 years before the primary cancer condition onset
+            this.fhirService.resourceParams['Observation'] = { date: 'ge' + newStringDate };
+            this.fhirService.resourceParams['Procedure'] = { date: 'ge' + newStringDate };
+            this.fhirService.resourceParams['MedicationStatement'] = { effective: 'ge' + newStringDate };
+          }
         }
+        this.fhirService.resourceTypes.map((resourceType) => {
+          this.fhirService.getResources(resourceType, this.fhirService.resourceParams[resourceType]).then((records) => {
+            this.bundleResources.push(
+              ...(records.filter((record) => {
+                // Check to make sure it's a bundle entry
+                return 'fullUrl' in record && 'resource' in record;
+              }) as fhirclient.FHIR.BundleEntry[])
+            );
+            //console.log(resourceType);
+            //console.log(records);
+            resourceTypeCount++;
+            if (this.fhirService.resourceTypes.length === resourceTypeCount) {
+              // remove loading screen when we've loaded our final resource type
+              this.spinner.hide('load-record');
+            }
+          });
+        });
       });
-    });
   }
 
   /**

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -211,8 +211,6 @@ export class AppComponent {
                 return 'fullUrl' in record && 'resource' in record;
               }) as fhirclient.FHIR.BundleEntry[])
             );
-            //console.log(resourceType);
-            //console.log(records);
             resourceTypeCount++;
             if (this.fhirService.resourceTypes.length === resourceTypeCount) {
               // remove loading screen when we've loaded our final resource type

--- a/src/app/smartonfhir/client.service.ts
+++ b/src/app/smartonfhir/client.service.ts
@@ -21,19 +21,9 @@ export class ClientService {
   client: Client;
   patient: Patient;
   private pendingClient: Promise<Client> | null = null;
-  public resourceTypes = [
-    'Patient',
-    'Immunization',
-    'AllergyIntolerance',
-    'Condition',
-    'MedicationStatement',
-    'Observation',
-    'Procedure'
-  ];
+  public resourceTypes = ['Patient', 'Condition', 'MedicationStatement', 'Observation', 'Procedure'];
   public resourceParams = {
     Patient: {},
-    Immunization: {},
-    AllergyIntolerance: {},
     Condition: { 'clinical-status': 'active' },
     MedicationStatement: {},
     Observation: {},


### PR DESCRIPTION
This PR adds filtering the resources pulled from the FHIR server for the patient bundle by only pulling Observations, Procedures, and MedicationStatements dated later than 2 years before the onset date of the patients primaryCancerCondition. (If the patient does not have a primaryCancerCondition, the resources are pulled unfiltered.)

Questions for discussion:
1. Should we be filtering on a date besides the primaryCancerCondition? (It would have been interesting to grab resources in the Cancer Disorder value set, but you can only do that if the value set is already known to the server)
2. Is 2 years before the primaryCancerCondition date an appropriate time frame?
3. Is defaulting to pulling everything if primaryCancerCondition is not present appropriate behavior? 