### PR TITLE
Send patient bundle as JSON

### DIFF
--- a/src/app/bundle.ts
+++ b/src/app/bundle.ts
@@ -12,30 +12,32 @@ export function createPatientBundle(
   parameters: { [key: string]: Stringable },
   entries: fhirclient.FHIR.BundleEntry[]
 ): string {
-
-  let paramResource: ParameterResource = {resourceType: "Parameters", id: "0", parameter: []};
+  const paramResource: ParameterResource = { resourceType: 'Parameters', id: '0', parameter: [] };
   for (const p in parameters) {
     // Ignore null values, they indicate a parameter that should be ignored.
     const value = parameters[p];
     if (value === null) continue;
-    paramResource.parameter.push({name: p, valueString: value});
+    paramResource.parameter.push({ name: p, valueString: value });
   }
-  let patientBundle: PatientBundle = {resourceType: 'Bundle', type: 'collection', entry: [{resource: paramResource}]};
+  const patientBundle: PatientBundle = {
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [{ resource: paramResource }]
+  };
   entries.forEach((resource) => {
-    patientBundle.entry.push({fullUrl: resource.fullUrl, resource: resource.resource});
+    patientBundle.entry.push({ fullUrl: resource.fullUrl, resource: resource.resource });
   });
-  console.log(JSON.stringify(patientBundle));
   return JSON.stringify(patientBundle);
 }
 
 export interface ParameterResource {
   resourceType?: string;
   id?: string;
-  parameter?: {name: string, valueString: Stringable}[];
+  parameter?: { name: string; valueString: Stringable }[];
 }
 
 export interface PatientBundle {
   resourceType?: string;
   type?: string;
-  entry?: {resource: ParameterResource }[] | {fullUrl:string, resource: fhirclient.FHIR.Resource}[];
+  entry?: { resource: ParameterResource }[] | { fullUrl: string; resource: fhirclient.FHIR.Resource }[];
 }

--- a/src/app/bundle.ts
+++ b/src/app/bundle.ts
@@ -12,41 +12,30 @@ export function createPatientBundle(
   parameters: { [key: string]: Stringable },
   entries: fhirclient.FHIR.BundleEntry[]
 ): string {
-  let paramResource = `{
-                         "resourceType": "Parameters",
-                         "id": "0",
-                         "parameter": [`;
+
+  let paramResource: ParameterResource = {resourceType: "Parameters", id: "0", parameter: []};
   for (const p in parameters) {
     // Ignore null values, they indicate a parameter that should be ignored.
     const value = parameters[p];
     if (value === null) continue;
-    paramResource += `{
-                        "name": ${JSON.stringify(p)},
-                        "valueString": ${JSON.stringify(value)}
-                      },`;
+    paramResource.parameter.push({name: p, valueString: value});
   }
-  // need to remove final comma
-  paramResource = paramResource.slice(0, -1);
-  paramResource += `
-                     ]
-                    }
-                  },`;
-  let patientBundle =
-    `{
-                          "resourceType": "Bundle",
-                          "type": "collection",
-                          "entry": [
-                            {
-                              "resource": ` + paramResource;
-  //for (const resource in entries)
+  let patientBundle: PatientBundle = {resourceType: 'Bundle', type: 'collection', entry: [{resource: paramResource}]};
   entries.forEach((resource) => {
-    // for each instead
-    patientBundle += `
-    ${JSON.stringify({ fullUrl: resource.fullUrl, resource: resource.resource })},`;
+    patientBundle.entry.push({fullUrl: resource.fullUrl, resource: resource.resource});
   });
-  patientBundle = patientBundle.slice(0, -1);
-  patientBundle += `
-                      ]
-                     }`;
-  return patientBundle;
+  console.log(JSON.stringify(patientBundle));
+  return JSON.stringify(patientBundle);
+}
+
+export interface ParameterResource {
+  resourceType?: string;
+  id?: string;
+  parameter?: {name: string, valueString: Stringable}[];
+}
+
+export interface PatientBundle {
+  resourceType?: string;
+  type?: string;
+  entry?: {resource: ParameterResource }[] | {fullUrl:string, resource: fhirclient.FHIR.Resource}[];
 }

--- a/src/app/bundle.ts
+++ b/src/app/bundle.ts
@@ -11,7 +11,7 @@ type Stringable = string | number | boolean | null;
 export function createPatientBundle(
   parameters: { [key: string]: Stringable },
   entries: fhirclient.FHIR.BundleEntry[]
-): string {
+): PatientBundle {
   const paramResource: ParameterResource = { resourceType: 'Parameters', id: '0', parameter: [] };
   for (const p in parameters) {
     // Ignore null values, they indicate a parameter that should be ignored.
@@ -27,7 +27,7 @@ export function createPatientBundle(
   entries.forEach((resource) => {
     patientBundle.entry.push({ fullUrl: resource.fullUrl, resource: resource.resource });
   });
-  return JSON.stringify(patientBundle);
+  return patientBundle;
 }
 
 export interface ParameterResource {

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -7,8 +7,7 @@ import { AppConfigService } from './app-config.service';
 import { fhirclient } from 'fhirclient/lib/types';
 import * as fhirpath from 'fhirpath';
 import { GeolibInputCoordinates } from 'geolib/es/types';
-// Type alias for the patient bundle which presumably won't always be a string
-type PatientBundle = string;
+import { PatientBundle } from '../bundle';
 
 /**
  * Marks a path.
@@ -387,7 +386,7 @@ export class SearchService {
 
   searchClinicalTrials(patientBundle: PatientBundle, offset?: number, count = 10): Observable<SearchResultsBundle> {
     const query: ClinicalTrialQuery = { patientData: patientBundle, count: count };
-    const zipCode = JSON.parse(patientBundle).entry[0].resource.parameter[0].valueString;
+    const zipCode = patientBundle.entry[0].resource.parameter[0].valueString;
     if (offset > 0) {
       query.offset = offset;
     }


### PR DESCRIPTION
This Pull Request updates the `createPatientBundle()` method in `bundle.ts` to send a JSON object of the patient bundle instead of a string. I've verified that trialscope still works with this new implementation and have compared the outputs of this PR with the original string patient bundle format to confirm that they are still the same.

Pull requests into the clinical-trial-matching-engine require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why: No Tests.
- [x]	Does an update need to be made to the documentation with these changes? No.
- [x]	Does an update need to be made to the service wrappers/template? No.
- [x]	Does an update need to be made to the service library? No.
- [x] Was the new feature tested by unit tests? No.
- [x] Was the new feature tested by a manual, end-to-end test? Yes.