### PR TITLE
Added fix for empty patient bundle issue.

### DIFF
--- a/src/app/record-data/record-data.component.html
+++ b/src/app/record-data/record-data.component.html
@@ -24,7 +24,7 @@
     </ul>
     <h3>Observations:</h3>
     <ul>
-      <li *ngFor="let observation of observations">{{observation.effectiveDateTime.substr(0,10)}} : {{observation.code.text}} {{observation.valueQuantity !== null ? ' : ' + observation.valueQuantity.value + ' ' + observation.valueQuantity.unit : ''}}</li>
+      <li *ngFor="let observation of observations">{{observation.effectiveDateTime.substr(0,10)}} : {{observation.code.text}} {{observation.valueQuantity != null ||  observation.valueQuantity != undefined ? ' : ' + observation.valueQuantity.value + ' ' + observation.valueQuantity.unit : ''}}</li>
     </ul>
     <h3>Other Resources:</h3>
     <ul>

--- a/src/app/record-data/record-data.component.html
+++ b/src/app/record-data/record-data.component.html
@@ -24,7 +24,7 @@
     </ul>
     <h3>Observations:</h3>
     <ul>
-      <li *ngFor="let observation of observations">{{observation.effectiveDateTime.substr(0,10)}} : {{observation.code.text}} {{observation.valueQuantity != null ||  observation.valueQuantity != undefined ? ' : ' + observation.valueQuantity.value + ' ' + observation.valueQuantity.unit : ''}}</li>
+      <li *ngFor="let observation of observations">{{observation.effectiveDateTime.substr(0,10)}} : {{observation.code.text}} {{observation.valueQuantity !== null &&  observation.valueQuantity !== undefined ? ' : ' + observation.valueQuantity.value + ' ' + observation.valueQuantity.unit : ''}}</li>
     </ul>
     <h3>Other Resources:</h3>
     <ul>

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -102,12 +102,9 @@ export class SearchPageComponent implements OnInit {
           (next) => {
             if (next.total) this.setLoadingProgress(next.loaded, next.total);
             // Add the entries of the patient resource to the bundle resources array.
-            this.bundleResources.push(
-              ...(next.entries.filter((record) => {
-                // Check to make sure it's a bundle entry
-                return 'fullUrl' in record && 'resource' in record;
-              }) as BundleEntry[])
-            );
+            if (next.type === 'complete') {
+              this.bundleResources = next.entries;
+            }
           },
           (error) => {
             console.log(error);

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -102,7 +102,8 @@ export class SearchPageComponent implements OnInit {
           (next) => {
             if (next.total) this.setLoadingProgress(next.loaded, next.total);
             // Add the entries of the patient resource to the bundle resources array.
-            this.bundleResources.push(...(next.entries.filter((record) => {
+            this.bundleResources.push(
+              ...(next.entries.filter((record) => {
                 // Check to make sure it's a bundle entry
                 return 'fullUrl' in record && 'resource' in record;
               }) as BundleEntry[])

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -101,6 +101,12 @@ export class SearchPageComponent implements OnInit {
         this.patientService.getPatientData().subscribe(
           (next) => {
             if (next.total) this.setLoadingProgress(next.loaded, next.total);
+            // Add the entries of the patient resource to the bundle resources array.
+            this.bundleResources.push(...(next.entries.filter((record) => {
+                // Check to make sure it's a bundle entry
+                return 'fullUrl' in record && 'resource' in record;
+              }) as BundleEntry[])
+            );
           },
           (error) => {
             console.log(error);


### PR DESCRIPTION
This Pull Request fixes a bug where no patient bundle resources were being pulled into the engine, leaving its patient bundle empty (except for the parameters).
Prior to this bug fix, the record view would display 0 records, and this was confirmed true by checking the contents of the patient bundle via the console.
When tested on Moonshot-dev with BCT and patient Tesha491 Bogan287:
- Prior to the fix 40 trials would be returned
- Post bug-fix, 21 trials are returned.


Pull requests into the clinical-trial-matching-engine require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [N/A]	Does an update need to be made to the documentation with these changes?
- [N/A]	Does an update need to be made to the service wrappers/template?
- [N/A]	Does an update need to be made to the service library?
- [N/A] Was the new feature tested by unit tests? - The only thing missing from unit tests was the different possible checks for fullUrl && rescource in the record.
- [X] Was the new feature tested by a manual, end-to-end test?
