### PR TITLE
Use Zip code as backup if position not present

### DIFF
--- a/src/app/results/results.component.html
+++ b/src/app/results/results.component.html
@@ -18,7 +18,7 @@
     <div class="sort">
       <mat-form-field appearance="fill">
         <mat-label>Sort</mat-label>
-        <mat-select [(ngModel)]="sortType" (change)="applyFilter()">
+        <mat-select [(ngModel)]="sortType" (selectionChange)="applyFilter()">
           <mat-option value="likelihood">Match Likelihood</mat-option>
           <mat-option value="distance">Distance</mat-option>
           <mat-option value="saved">Saved</mat-option>

--- a/src/app/services/ResearchStudySearchEntry.ts
+++ b/src/app/services/ResearchStudySearchEntry.ts
@@ -288,16 +288,15 @@ export class ResearchStudySearchEntry {
         }
         // If not, look to see if there is a postal code
         else if (loc.address && loc.address.postalCode && loc.address.country) {
-            // Check to see if the country and zip code are US patterns.
-            const country = united_states.exec(loc.address.country);
-            const zip = us_zip.exec(loc.address.postalCode);
+          // Check to see if the country and zip code are US patterns.
+          const country = united_states.exec(loc.address.country);
+          const zip = us_zip.exec(loc.address.postalCode);
 
-            // If so, use the zip to find the coordinates and then push accordingly.
-            if (country != null && zip != null) {
-              const coordinate = this.distService.getCoord(loc.address.postalCode) as GeolibInputCoordinates;
-              points.push(coordinate);
-            }
-            
+          // If so, use the zip to find the coordinates and then push accordingly.
+          if (country != null && zip != null) {
+            const coordinate = this.distService.getCoord(loc.address.postalCode) as GeolibInputCoordinates;
+            points.push(coordinate);
+          }
         }
       }
     }

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -35,9 +35,9 @@ export interface Location extends BaseResource {
   address?: Address;
 }
 
-export interface Address{
-  country?: string,
-  postalCode?: string
+export interface Address {
+  country?: string;
+  postalCode?: string;
 }
 
 /**

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -32,6 +32,12 @@ export interface Location extends BaseResource {
   name?: string;
   telecom?: unknown;
   position?: { longitude?: number; latitude?: number };
+  address?: Address;
+}
+
+export interface Address{
+  country?: string,
+  postalCode?: string
 }
 
 /**


### PR DESCRIPTION
There was an issue in which the clinical trials' distances were being resolved as `null`. This was due to trials not having lat/long in the Location (position). This resolves that issue as best as possible by utilizing the `address` field and using the zip code (if present in the US) as a backup. 

Also resolves issues with sorting drop down not working. 